### PR TITLE
Neue Darstellung IN1/2, umschaltbare Ausgabe, RESET im Menue (long pr…

### DIFF
--- a/src/SWR_METER_ohne_TFT/SWR_METER_ohne_TFT.ino
+++ b/src/SWR_METER_ohne_TFT/SWR_METER_ohne_TFT.ino
@@ -677,6 +677,9 @@ void check_encoder() {
             writeEEPROM();
             refresh = true;
             menuState = SWR;
+            // wir setzen die temporaren Werte auch auf die gewaehlte Frequenz
+            QRGidx1=frequenzIdx;
+            QRGidx2=frequenzIdx;
             break;
           case 1: // Konfiguration Kanal 1
             configureInput(1);


### PR DESCRIPTION
…essed)

Einige Bugs behoben
- IN1/2: <Button> schaltet in den Wahlmodus der Ausgabegroesse:
IN: Eingang Powermeter
AT: Eingang externer Abschwaecher
KO: Eingang Koppler (+ Abschwaecher, wenn extra definiert)

Long Press >3s im Hauptmenue zeigt Kalibrierungswerte an, dort ist nun ein RESET moeglich

IRQ fuer Button auf CHNAGE umgestellt, da Loslassen des Buttons erkannt werden muss